### PR TITLE
Ejercicio trigger consigna 1

### DIFF
--- a/force-app/main/default/classes/AccountManage.cls
+++ b/force-app/main/default/classes/AccountManage.cls
@@ -1,0 +1,60 @@
+public with sharing class AccountManage {
+    
+    public static string createAccount(string name, integer numberOfEmploees, string documentType, string documentNumber){
+		Account anAccount =  new Account(
+			name = name,
+			NumberOfEmployees = numberOfEmploees,
+			Identification_type__c = documentType,
+			Document_Number__c = documentNumber
+		);
+	
+		insert anAccount;
+		return anAccount.Id;
+    }
+    
+    public static Boolean updateAccount(string name, integer numberOfEmploees, string documentType, string documentNumber){
+        Account anAccount = consultAccount(documentType, documentNumber);
+        anAccount.Name = name;
+        anAccount.NumberOfEmployees = numberOfEmploees;
+        Database.SaveResult result = Database.update(anAccount, false);
+        return result.isSuccess();
+    }
+    
+    public static Boolean deleteAccount(string documentType, string documentNumber){
+        Account anAccount = consultAccount(documentType, documentNumber);
+        if (anAccount == null)
+            return false;
+        Database.DeleteResult result = Database.delete(anAccount, false);
+        return result.isSuccess();
+    }
+    
+    public static Account consultAccount(string documentType, string documentNumber){
+        try{
+            return [
+                SELECT Id, name, NumberOfEmployees, Identification_type__c, Document_Number__c
+                FROM Account 
+                WHERE Identification_type__c = :documentType 
+                AND Document_Number__c = :documentNumber
+                LIMIT 1
+            ];
+        } catch(Exception e){
+            return null;
+        }
+    } 
+
+    public static void createOpportunity(List<Account> accounts) {
+        List<Opportunity> opportunities = new List<Opportunity>();
+        for (Account anAccount : accounts) {
+            if (anAccount.opportunity__c) {
+                opportunities.add(new Opportunity(
+                    Name='Opportunity ' + anAccount.Name + System.Today(),
+                    AccountID=anAccount.Id,
+                    StageName='Prospection',
+                    CloseDate=System.Today().addDays(30)
+                ));
+            }
+        }
+        insert opportunities;
+    }
+    
+}

--- a/force-app/main/default/classes/AccountManagerTest.cls
+++ b/force-app/main/default/classes/AccountManagerTest.cls
@@ -1,0 +1,27 @@
+@isTest
+private class AccountManagerTest {
+    
+    @isTest
+    static void testGetAccount() {
+        Id recordId = createAccountWithContact();
+        RestRequest request = new RestRequest();
+        request.requestUri =
+            'https://globant-3b8-dev-ed.lightning.force.com/services/apexrest//Accounts/'+ recordId+'/contacts';
+            request.httpMethod = 'GET';
+            RestContext.request = request;
+            Account thisAccount = AccountManager.getAccount();
+            System.assert(thisAccount != null);
+            System.assertEquals('Test Account', thisAccount.Name);
+    }
+    
+    private static Id createAccountWithContact(){
+        Account acc = new Account(Name = 'Test Account');
+        insert acc;
+        Contact con1 = new Contact(firstname = 'con1', lastname = 'con1last', accountId = acc.Id );
+        insert con1;
+        Contact con2 = new Contact(firstname = 'con2', lastname = 'con2last', accountId = acc.Id );
+        insert con2;
+        return acc.Id;
+    }
+
+}

--- a/force-app/main/default/classes/AccountTriggerTest.cls
+++ b/force-app/main/default/classes/AccountTriggerTest.cls
@@ -1,0 +1,77 @@
+@IsTest
+private class AccountTriggerTest {
+    @TestSetup
+    static void makeData(){
+        Account anAccount =  new Account(
+			Name = 'My Account',
+			NumberOfEmployees = 99,
+			Identification_type__c = 'NIT',
+			Document_Number__c = '123'
+		);
+        insert anAccount;
+    }
+    @IsTest
+    static void createAccountWithNewIds() {
+        Account anAccount =  new Account(
+			Name = 'My Account new',
+			NumberOfEmployees = 99,
+			Identification_type__c = 'NIT',
+			Document_Number__c = '456'
+		);
+        Test.startTest();
+        insert anAccount;
+        Test.stopTest();
+        List<Account> accounts = [
+            SELECT Name, NumberOfEmployees, Identification_type__c,	Document_Number__c
+            FROM Account
+            WHERE Name = 'My Account new'
+        ];
+        System.assertEquals(1, accounts.size(), 'No se ha guardado la cuenta nueva o no es la unica.');
+    }
+    @IsTest
+    static void createAccountWithSameIds() {
+        Account anAccount =  new Account(
+			Name = 'My Account new',
+			NumberOfEmployees = 99,
+			Identification_type__c = 'NIT',
+			Document_Number__c = '123'
+		);
+        Test.startTest();
+        Database.SaveResult result = Database.insert(anAccount, false);
+        Test.stopTest();
+        List<Account> accounts = [
+            SELECT Name, NumberOfEmployees, Identification_type__c,	Document_Number__c
+            FROM Account
+            WHERE Name = 'My Account new'
+        ];
+        System.assertEquals(false, result.isSuccess(), 'Ha insertado la cuenta a pesar de tener mismos tipo y numero de documento.');
+        System.assertEquals(0, accounts.size(), 'Ha insertado la cuenta a pesar de tener mismos tipo y numero de documento.');
+    }
+    @IsTest
+    static void createAccountWithMixIds() {
+        Account anAccount1 =  new Account(
+			Name = 'My Account new',
+			NumberOfEmployees = 99,
+			Identification_type__c = 'NIT',
+			Document_Number__c = '123'
+		);
+        Account anAccount2 =  new Account(
+			Name = 'My Account new',
+			NumberOfEmployees = 99,
+			Identification_type__c = 'NIT',
+			Document_Number__c = '456'
+		);
+        List<Account> accounts = new List<Account>();
+        accounts.add(anAccount1);
+        accounts.add(anAccount2);
+        Test.startTest();
+        List<Database.SaveResult> result = Database.insert(accounts, false);
+        Test.stopTest();
+        List<Account> accountsToCompare = [
+            SELECT Name, NumberOfEmployees, Identification_type__c,	Document_Number__c
+            FROM Account
+            WHERE Name = 'My Account new'
+        ];
+        System.assertEquals(1, accountsToCompare.size(), 'Solo deberia haber insertado una cuenta.');
+    }
+}

--- a/force-app/main/default/classes/AccountValidation.cls
+++ b/force-app/main/default/classes/AccountValidation.cls
@@ -1,0 +1,30 @@
+public class AccountValidation {
+
+    public static void validateAccount(List<Account> accounts) {
+
+        Set<String> toCompareType = new Set<string>();
+        Set<String> toCompareNumber = new Set<string>();
+        for (Account anAccount : accounts) {
+            toCompareType.add(anAccount.Identification_type__c);
+            toCompareNumber.add(anAccount.Document_Number__c);
+        }
+
+        List<Account> accountsToCompare = [
+            SELECT Id, name, NumberOfEmployees, Identification_type__c, Document_Number__c
+            FROM Account 
+            WHERE Identification_type__c IN :toCompareType
+            	AND Document_Number__c IN :toCompareNumber
+        ];
+        
+        for (Account anAccount1 : accounts) {
+            for (Account anAccount2 : accountsToCompare) {
+                if (anAccount1.Document_Number__c == anAccount2.Document_Number__c
+                    && anAccount1.Identification_type__c == anAccount2.Identification_type__c
+                    && anAccount1.Id != anAccount2.Id)
+	            anAccount1.AddError('There is already a Account with that name.');
+            }
+        }
+        
+    }
+    
+}

--- a/force-app/main/default/triggers/AccountTrigger.trigger
+++ b/force-app/main/default/triggers/AccountTrigger.trigger
@@ -1,0 +1,10 @@
+trigger AccountTrigger on Account (before insert, before update) {
+    if (Trigger.isBefore) {
+        if (Trigger.isInsert) {
+            AccountValidation.validateAccount(Trigger.new);
+        }
+        if (Trigger.isUpdate) {
+            AccountValidation.validateAccount(Trigger.new);
+        }
+    }
+}


### PR DESCRIPTION
Resumen: Crear un trigger para validar una cuenta cuando se crea o actualiza segun tenga mismo tipo y numero de documento que otra existente. Se agrega el metodo crear oportunidades para una lista de cuentas.

Se afectaron las siguientes clases:	
- AccountValidation
- AccountTrigger
- AccountManage
- AccountManageTest
- AccountTriggerTest

*Se veran metodos extra porque se usan para otros ejercicios pero no deberian afectar la funcionalidad actual.